### PR TITLE
Switch 1/> object leak warning format from () to /

### DIFF
--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -275,7 +275,7 @@ def main(fd):
                     else:
                         warnings.warn(
                             f'resource_tracker: There appears to be '
-                            f'{len(rtype_cache)} leaked {rtype} object(s) to '
+                            f'{len(rtype_cache)} leaked {rtype} object/s to '
                             f'clean up at shutdown: {rtype_cache}'
                         )
                 except Exception:

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4488,7 +4488,7 @@ class _TestSharedMemory(BaseTestCase):
                 # Without this line it was raising warnings like:
                 #   UserWarning: resource_tracker:
                 #   There appears to be 1 leaked shared_memory
-                #   object(s) to clean up at shutdown
+                #   object/s to clean up at shutdown
                 # See: https://bugs.python.org/issue45209
                 resource_tracker.unregister(f"/{name}", "shared_memory")
 
@@ -4498,7 +4498,7 @@ class _TestSharedMemory(BaseTestCase):
                 err = p.stderr.read().decode()
                 self.assertIn(
                     "resource_tracker: There appears to be 1 leaked "
-                    "shared_memory object(s) to clean up at shutdown", err)
+                    "shared_memory object/s to clean up at shutdown", err)
 
     @unittest.skipIf(os.name != "posix", "resource_tracker is posix only")
     def test_shared_memory_untracking(self):
@@ -4544,7 +4544,7 @@ class _TestSharedMemory(BaseTestCase):
             self.assertEqual(rc, 0)
             self.assertIn(
                 b"resource_tracker: There appears to be 1 leaked "
-                b"shared_memory object(s) to clean up at shutdown", err)
+                b"shared_memory object/s to clean up at shutdown", err)
         finally:
             try:
                 mem.unlink()
@@ -5680,7 +5680,7 @@ class TestResourceTracker(unittest.TestCase):
                 err = p.stderr.read().decode('utf-8')
                 p.stderr.close()
                 expected = ('resource_tracker: There appears to be 2 leaked {} '
-                            'object(s)'.format(
+                            'object/s'.format(
                             rtype))
                 self.assertRegex(err, expected)
                 self.assertRegex(err, r'resource_tracker: %r: \[Errno' % name1)
@@ -6197,7 +6197,7 @@ class TestNamedResource(unittest.TestCase):
             '''))
         rc, out, err = script_helper.assert_python_ok(testfn)
         # on error, err = 'UserWarning: resource_tracker: There appears to
-        # be 1 leaked semaphore object(s) to clean up at shutdown'
+        # be 1 leaked semaphore object/s to clean up at shutdown'
         self.assertFalse(err, msg=err.decode('utf-8'))
 
 


### PR DESCRIPTION
CI/CD pipeline showed that there was an issue with enabling parentheses in the original warning (even after attempting to escape characters).
This PR is a workaround to replace the character entirely in the object leak warning and related unit-tests & comments.